### PR TITLE
[Feat] 공통 엔티티 추출 및 적용

### DIFF
--- a/backend/src/main/java/us/stcorp/team3/hackathonproject/HackathonProjectApplication.java
+++ b/backend/src/main/java/us/stcorp/team3/hackathonproject/HackathonProjectApplication.java
@@ -2,8 +2,10 @@ package us.stcorp.team3.hackathonproject;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class HackathonProjectApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/us/stcorp/team3/hackathonproject/common/BaseTimeEntity.java
+++ b/backend/src/main/java/us/stcorp/team3/hackathonproject/common/BaseTimeEntity.java
@@ -12,7 +12,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
-public class BaseTimeEntity {
+public abstract class BaseTimeEntity {
 
     @CreatedDate
     @Column(updatable = false)

--- a/backend/src/main/java/us/stcorp/team3/hackathonproject/common/BaseTimeEntity.java
+++ b/backend/src/main/java/us/stcorp/team3/hackathonproject/common/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package us.stcorp.team3.hackathonproject.common;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/Category.java
+++ b/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/Category.java
@@ -1,6 +1,5 @@
 package us.stcorp.team3.hackathonproject.domain;
 
-import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -11,14 +10,13 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
+import us.stcorp.team3.hackathonproject.common.BaseTimeEntity;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
 @Entity
-public class Category {
+public class Category extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,17 +25,8 @@ public class Category {
 
     @NotNull
     private String name;
-
-    @NotNull
-    @Column(insertable = false, updatable = false, columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP")
-    @CreatedDate
-    private LocalDateTime createdAt;
     @NotNull
     private String createdBy;
-    @NotNull
-    @Column(insertable = false, updatable = false, columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP")
-    @LastModifiedDate
-    private LocalDateTime modifiedAt;
     @NotNull
     private String modifiedBy;
 

--- a/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/Matzip.java
+++ b/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/Matzip.java
@@ -54,7 +54,7 @@ public class Matzip {
     @NotNull
     private String modifiedBy;
 
-    @ManyToOne(targetEntity = Category.class, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "CATEGORY_ID")
     private Category category;
 

--- a/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/Matzip.java
+++ b/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/Matzip.java
@@ -1,7 +1,5 @@
 package us.stcorp.team3.hackathonproject.domain;
 
-import java.time.LocalDateTime;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
@@ -15,16 +13,15 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import us.stcorp.team3.hackathonproject.common.BaseTimeEntity;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
 @EntityListeners(AuditingEntityListener.class)
 @Entity
-public class Matzip {
+public class Matzip extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,17 +37,8 @@ public class Matzip {
     private Integer likeCount;
     private String distance;
     private String price;
-
-    @NotNull
-    @Column(insertable = false, updatable = false, columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP")
-    @CreatedDate
-    private LocalDateTime createdAt;
     @NotNull
     private String createdBy;
-    @NotNull
-    @Column(insertable = false, updatable = false, columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP")
-    @LastModifiedDate
-    private LocalDateTime modifiedAt;
     @NotNull
     private String modifiedBy;
 

--- a/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/MatzipReview.java
+++ b/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/MatzipReview.java
@@ -49,7 +49,7 @@ public class MatzipReview {
     @NotNull
     private String modifiedBy;
 
-    @ManyToOne(targetEntity = Matzip.class, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "MATZIP_ID")
     private Matzip matzip;
 

--- a/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/MatzipReview.java
+++ b/backend/src/main/java/us/stcorp/team3/hackathonproject/domain/MatzipReview.java
@@ -1,7 +1,5 @@
 package us.stcorp.team3.hackathonproject.domain;
 
-import java.time.LocalDateTime;
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -14,14 +12,13 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
+import us.stcorp.team3.hackathonproject.common.BaseTimeEntity;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @ToString
 @Entity
-public class MatzipReview {
+public class MatzipReview extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,17 +32,8 @@ public class MatzipReview {
 
     @NotNull
     private String password;
-
-    @NotNull
-    @Column(insertable = false, updatable = false, columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP")
-    @CreatedDate
-    private LocalDateTime createdAt;
     @NotNull
     private String createdBy;
-    @NotNull
-    @Column(insertable = false, updatable = false, columnDefinition = "datetime DEFAULT CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP")
-    @LastModifiedDate
-    private LocalDateTime modifiedAt;
     @NotNull
     private String modifiedBy;
 

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -9,6 +9,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+    show-sql: true
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 🛠작업 내용
- 생성일지, 수정일시를 공통 엔티티로 추출
- JPA Auditing을 사용하기 위해 애노테이션 추가
- 공통 엔티티를 상속받도록 변경
